### PR TITLE
feat: remove trees with zero stems

### DIFF
--- a/lukefi/metsi/domain/natural_processes/grow_motti_dll.py
+++ b/lukefi/metsi/domain/natural_processes/grow_motti_dll.py
@@ -16,6 +16,7 @@ from lukefi.metsi.data.model import ForestStand, MottiState
 from lukefi.metsi.data.vector_model import ReferenceTrees, TreeStrata
 from lukefi.metsi.domain.natural_processes.natural_process_wrapper import natural_process_transition
 from lukefi.metsi.domain.natural_processes.util import update_stand_growth
+from lukefi.metsi.forestry.treatment_utils import prune_zero_stems_transition
 from lukefi.metsi.sim.collected_data import OpTuple
 
 
@@ -455,6 +456,7 @@ def species_to_motti(spe: int) -> int:
     raise ValueError(f"Unsupported tree species code: {int(spe)}")
 
 @natural_process_transition
+@prune_zero_stems_transition
 def grow_motti_dll_fn(input_: ForestStand, step: int = 5, /, **operation_parameters) -> OpTuple[ForestStand]:
     """
     Vector-only Motti grow:

--- a/lukefi/metsi/forestry/harvest/cutting.py
+++ b/lukefi/metsi/forestry/harvest/cutting.py
@@ -2,12 +2,14 @@ import numpy as np
 from lukefi.metsi.app.utils import MetsiException
 from lukefi.metsi.data.model import ForestStand
 from lukefi.metsi.data.vector_model import ReferenceTrees
+from lukefi.metsi.forestry.treatment_utils import prune_zero_stems_treatment
 from lukefi.metsi.sim.collected_data import OpTuple, CollectedData
 from lukefi.metsi.data.util.select_units import select_units, SelectionSet, SelectionTarget
 from lukefi.metsi.domain.collected_data import RemovedTrees
 from lukefi.metsi.sim.treatment import Treatment
 
 
+@prune_zero_stems_treatment
 def cutting_fn(input_: ForestStand, /, **operation_parameters) -> OpTuple[ForestStand]:
     """
     cutting treatment:

--- a/lukefi/metsi/forestry/treatment_utils.py
+++ b/lukefi/metsi/forestry/treatment_utils.py
@@ -1,5 +1,4 @@
 from typing import Mapping, Any
-
 import numpy as np
 from lukefi.metsi.app.utils import MetsiException
 from lukefi.metsi.data.model import ForestStand
@@ -17,9 +16,8 @@ def req(params: Mapping[str, Any], name: str) -> Any:
         ) from exc
 
 
-def prune_zero_stems(func: TreatmentFn[ForestStand] | TransitionFn[ForestStand]
-                     ) -> TreatmentFn[ForestStand] | TransitionFn[ForestStand]:
-    def prune_zero_stems_wrapper(stand: ForestStand, **parameters) -> OpTuple[ForestStand]:
+def prune_zero_stems_treatment(func: TreatmentFn[ForestStand]) -> TreatmentFn[ForestStand]:
+    def prune_zero_stems_treatment_wrapper(stand: ForestStand, **parameters) -> OpTuple[ForestStand]:
         new_stand, collected_data = func(stand, **parameters)
         trees = new_stand.reference_trees
         zero_stems_indices = np.nonzero(trees.stems_per_ha == 0)[0]
@@ -27,4 +25,16 @@ def prune_zero_stems(func: TreatmentFn[ForestStand] | TransitionFn[ForestStand]
 
         return new_stand, collected_data
 
-    return prune_zero_stems_wrapper
+    return prune_zero_stems_treatment_wrapper
+
+
+def prune_zero_stems_transition(func: TransitionFn[ForestStand]) -> TransitionFn[ForestStand]:
+    def prune_zero_stems_transition_wrapper(stand: ForestStand, step: int, **parameters) -> OpTuple[ForestStand]:
+        new_stand, collected_data = func(stand, step, **parameters)
+        trees = new_stand.reference_trees
+        zero_stems_indices = np.nonzero(trees.stems_per_ha == 0)[0]
+        trees.delete(zero_stems_indices)
+
+        return new_stand, collected_data
+
+    return prune_zero_stems_transition_wrapper

--- a/lukefi/metsi/forestry/treatment_utils.py
+++ b/lukefi/metsi/forestry/treatment_utils.py
@@ -1,3 +1,4 @@
+from functools import wraps
 from typing import Mapping, Any
 import numpy as np
 from lukefi.metsi.app.utils import MetsiException
@@ -17,6 +18,7 @@ def req(params: Mapping[str, Any], name: str) -> Any:
 
 
 def prune_zero_stems_treatment(func: TreatmentFn[ForestStand]) -> TreatmentFn[ForestStand]:
+    @wraps(func)
     def prune_zero_stems_treatment_wrapper(stand: ForestStand, **parameters) -> OpTuple[ForestStand]:
         new_stand, collected_data = func(stand, **parameters)
         trees = new_stand.reference_trees
@@ -29,6 +31,7 @@ def prune_zero_stems_treatment(func: TreatmentFn[ForestStand]) -> TreatmentFn[Fo
 
 
 def prune_zero_stems_transition(func: TransitionFn[ForestStand]) -> TransitionFn[ForestStand]:
+    @wraps(func)
     def prune_zero_stems_transition_wrapper(stand: ForestStand, step: int, **parameters) -> OpTuple[ForestStand]:
         new_stand, collected_data = func(stand, step, **parameters)
         trees = new_stand.reference_trees

--- a/lukefi/metsi/forestry/treatment_utils.py
+++ b/lukefi/metsi/forestry/treatment_utils.py
@@ -1,5 +1,12 @@
 from typing import Mapping, Any
+
+import numpy as np
 from lukefi.metsi.app.utils import MetsiException
+from lukefi.metsi.data.model import ForestStand
+from lukefi.metsi.sim.collected_data import OpTuple
+from lukefi.metsi.sim.sim_configuration import TransitionFn
+from lukefi.metsi.sim.treatment import TreatmentFn
+
 
 def req(params: Mapping[str, Any], name: str) -> Any:
     try:
@@ -8,3 +15,16 @@ def req(params: Mapping[str, Any], name: str) -> Any:
         raise MetsiException(
             f"Missing required regeneration parameter: '{name}'"
         ) from exc
+
+
+def prune_zero_stems(func: TreatmentFn[ForestStand] | TransitionFn[ForestStand]
+                     ) -> TreatmentFn[ForestStand] | TransitionFn[ForestStand]:
+    def prune_zero_stems_wrapper(stand: ForestStand, **parameters) -> OpTuple[ForestStand]:
+        new_stand, collected_data = func(stand, **parameters)
+        trees = new_stand.reference_trees
+        zero_stems_indices = np.nonzero(trees.stems_per_ha == 0)[0]
+        trees.delete(zero_stems_indices)
+
+        return new_stand, collected_data
+
+    return prune_zero_stems_wrapper

--- a/lukefi/metsi/forestry/treatment_utils.py
+++ b/lukefi/metsi/forestry/treatment_utils.py
@@ -4,7 +4,7 @@ import numpy as np
 from lukefi.metsi.app.utils import MetsiException
 from lukefi.metsi.data.model import ForestStand
 from lukefi.metsi.sim.collected_data import OpTuple
-from lukefi.metsi.sim.sim_configuration import TransitionFn
+from lukefi.metsi.sim.transition import TransitionFn
 from lukefi.metsi.sim.treatment import TreatmentFn
 
 

--- a/tests/domain/natural_processes/grow_motti_test.py
+++ b/tests/domain/natural_processes/grow_motti_test.py
@@ -12,7 +12,7 @@ from lukefi.metsi.domain.natural_processes.motti_dll_wrapper import Motti4DLL
 import lukefi.metsi.domain.natural_processes.grow_motti_dll as grow_motti
 from lukefi.metsi.domain.natural_processes.motti_dll_wrapper import GrowthDeltas
 from lukefi.metsi.data.enums.internal import DrainageCategory
-from lukefi.metsi.data.vector_model import TreeStrata
+from lukefi.metsi.data.vector_model import ReferenceTrees, TreeStrata
 
 from lukefi.metsi.domain.natural_processes.grow_motti_dll import (
     resolve_shared_object,
@@ -40,7 +40,7 @@ def make_empty_sapling() -> SimpleNamespace:
     )
 
 
-def make_stand_vec(rt: SimpleNamespace) -> SimpleNamespace:
+def make_stand_vec(rt: ReferenceTrees | SimpleNamespace) -> SimpleNamespace:
     sap = make_empty_sapling()
     return SimpleNamespace(
         time=2000,
@@ -133,6 +133,9 @@ class FakeDLL:
         return SimpleNamespace(buffers="ok", ctrl=ctrl)
 
     def grow_with_state(self, *_args: Any, **_kwargs: Any) -> GrowthDeltas:
+        _ = _args
+        _ = _kwargs
+        
         if not self.captured_trees_py:
             return GrowthDeltas(
                 tree_ids=[],
@@ -272,7 +275,7 @@ class TestMottiPathResolversAndWrapperUtils(unittest.TestCase):
             # Try data/motti marker
             for p in (base / ".git",):
                 if p.exists() and p.is_dir():
-                    for _child in p.iterdir():
+                    for _ in p.iterdir():
                         pass
                 # clean .git directory
             # Safer: use a fresh temp directory for clarity
@@ -326,16 +329,22 @@ class TestGrowMottiDLLVec(unittest.TestCase):
 
     def test_vector_grow_applies_deltas_and_handles_deaths(self) -> None:
         # Two trees; DLL returns growth only for tree 1; tree 2 "dies" (missing -> stems=0)
-        rt = make_rt(
-            stems=(100.0, 80.0),
-            d=(10.0, 12.0),
-            h=(12.0, 14.0),
-            species=(2, 3),
-        )
+        rt = ReferenceTrees(2)
+        rt.stems_per_ha[0] = 100.0
+        rt.stems_per_ha[1] = 80.0
+        rt.breast_height_diameter[0] = 10.0
+        rt.breast_height_diameter[1] = 12.0
+        rt.height[0] = 12.0
+        rt.height[1] = 14.0
+        rt.species[0] = 2
+        rt.species[1] = 3
         stand = make_stand_vec(rt)
 
         class GrowingDLL(FakeDLL):
             def grow_with_state(self, *args: Any, **kwargs: Any) -> GrowthDeltas:  # noqa: D401
+                _ = args
+                _ = kwargs
+
                 # Only tree id=1 grows / survives
                 return GrowthDeltas(
                     tree_ids=[1],
@@ -359,13 +368,13 @@ class TestGrowMottiDLLVec(unittest.TestCase):
         self.assertIsNotNone(out_stand.reference_trees)
         rt_out = out_stand.reference_trees
         assert rt_out is not None
-
+        assert len(rt_out) == 1
         # tree 1 updated by deltas
         self.assertAlmostEqual(rt_out.breast_height_diameter[0], 10.0 + 0.7, places=6)
         self.assertAlmostEqual(rt_out.height[0], 12.0 + 1.2, places=6)
         self.assertAlmostEqual(rt_out.stems_per_ha[0], 100.0 - 5.0, places=6)
 
-        # tree 2 missing from DLL result → stems set to 0 (d, h unchanged)
-        self.assertAlmostEqual(rt_out.breast_height_diameter[1], 12.0, places=6)
-        self.assertAlmostEqual(rt_out.height[1], 14.0, places=6)
-        self.assertEqual(float(rt_out.stems_per_ha[1]), 0.0)
+        # tree 2 missing from DLL result → stems set to 0 (d, h unchanged) → tree deleted by prune_zero_stems
+        # self.assertAlmostEqual(rt_out.breast_height_diameter[1], 12.0, places=6)
+        # self.assertAlmostEqual(rt_out.height[1], 14.0, places=6)
+        # self.assertEqual(float(rt_out.stems_per_ha[1]), 0.0)


### PR DESCRIPTION
Added a wrapper for transition and treatment functions to remove reference trees with zero `stems_per_ha` after executing the function.