### PR TITLE
fix: test area handling class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.6.8] - 2026-04-14
+
+### Fixed
+
+- Fixed `test_area_handling_class` checks in `determine_forest_management_category`
+
 ## [0.6.7] - 2026-04-14
 
 ### Fixed

--- a/lukefi/metsi/data/formats/vmi_util.py
+++ b/lukefi/metsi/data/formats/vmi_util.py
@@ -326,21 +326,18 @@ def determine_forest_management_category(land_use_category: int,
         decimals = 0.7
 
     # Metsähallituksen rajoitukset;
-    mh_pt = 5
-
     try:
         test_area_handling_class_numeric = float(test_area_handling_class)
-        if (test_area_handling_class_numeric == 1 and mh_pt == 5):
+        if test_area_handling_class_numeric == 1:
             mh_pt = 3
-
-        if (test_area_handling_class_numeric == 2 and mh_pt == 5):
+        elif test_area_handling_class_numeric == 2:
             mh_pt = 2
-
-        if (test_area_handling_class_numeric in (3.1, 3.2) and mh_pt == 5):
+        elif test_area_handling_class_numeric in (3.1, 3.2):
             mh_pt = 1
-
+        else:
+            mh_pt = 5
     except ValueError:
-        pass
+        mh_pt = 5
 
     if mh_pt < vmi_pt:
         decimals = 0.8

--- a/lukefi/metsi/data/formats/vmi_util.py
+++ b/lukefi/metsi/data/formats/vmi_util.py
@@ -328,14 +328,19 @@ def determine_forest_management_category(land_use_category: int,
     # Metsähallituksen rajoitukset;
     mh_pt = 5
 
-    if (test_area_handling_class == '1' and mh_pt == 5):
-        mh_pt = 3
+    try:
+        test_area_handling_class_numeric = float(test_area_handling_class)
+        if (test_area_handling_class_numeric == 1 and mh_pt == 5):
+            mh_pt = 3
 
-    if (test_area_handling_class == '2' and mh_pt == 5):
-        mh_pt = 2
+        if (test_area_handling_class_numeric == 2 and mh_pt == 5):
+            mh_pt = 2
 
-    if (test_area_handling_class in ('3.1', '3.2') and mh_pt == 5):
-        mh_pt = 1
+        if (test_area_handling_class_numeric in (3.1, 3.2) and mh_pt == 5):
+            mh_pt = 1
+
+    except ValueError:
+        pass
 
     if mh_pt < vmi_pt:
         decimals = 0.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "lukefi.mela2"
 description = "Mela2.0 forestry simulator."
-version = "0.6.7"
+version = "0.6.8"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [


### PR DESCRIPTION
`test_area_handling_class` is now converted into float before comparisons when determining `mh_pt` in `determine_forest_management_category`.