### PR TITLE
fix: `total_len` as integer in RST C-variable metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.6.9] - 2026-04-15
+
+### Fixed
+
+- Changed RST C-variable total length field to integer type
+
 ## [0.6.8] - 2026-04-14
 
 ### Fixed

--- a/lukefi/metsi/data/formats/io_utils.py
+++ b/lukefi/metsi/data/formats/io_utils.py
@@ -74,7 +74,7 @@ def msb_metadata(stand: ForestStand) -> tuple[list[str], list[str], list[str]]:
 
 def c_var_metadata(uid: float | None, cvars_len: int) -> list[str]:
     total_length = 2 + cvars_len
-    cvars_meta = [rst_float(uid or 0), str(total_length), rst_float(2), rst_float(cvars_len)]
+    cvars_meta = [rst_float(uid or 0), str(total_length), "2.000000", rst_float(cvars_len)]
     return list(cvars_meta)
 
 

--- a/lukefi/metsi/data/formats/io_utils.py
+++ b/lukefi/metsi/data/formats/io_utils.py
@@ -74,7 +74,7 @@ def msb_metadata(stand: ForestStand) -> tuple[list[str], list[str], list[str]]:
 
 def c_var_metadata(uid: float | None, cvars_len: int) -> list[str]:
     total_length = 2 + cvars_len
-    cvars_meta = map(rst_float, [uid or 0, total_length, 2, cvars_len])
+    cvars_meta = [rst_float(uid or 0), str(total_length), rst_float(2), rst_float(cvars_len)]
     return list(cvars_meta)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "lukefi.mela2"
 description = "Mela2.0 forestry simulator."
-version = "0.6.8"
+version = "0.6.9"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/tests/data/formats/io_test.py
+++ b/tests/data/formats/io_test.py
@@ -29,7 +29,7 @@ class TestCVarRstRow(unittest.TestCase):
     def test_c_var_rst_row(self):
         cvar_decl = ["var1", "var2", "var3"]
         result = c_var_rst_row(self.mock_stand, cvar_decl)
-        expected = "123.000000 5.000000 2.000000 3.000000 1.230000 4.560000 7.890000"
+        expected = "123.000000 5 2.000000 3.000000 1.230000 4.560000 7.890000"
         self.assertEqual(result, expected)
 
 


### PR DESCRIPTION
Excluded `total_len` from `rst_float` conversion in `c_var_metadata`.