### PR TITLE
feat: better progress prints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.6.13] - 2026-04-21
+
+### Added
+
+- Added progress logging to `simulate_alternatives`
+
 ## [0.6.12] - 2026-04-21
 
 ### Added

--- a/lukefi/metsi/domain/pre_ops.py
+++ b/lukefi/metsi/domain/pre_ops.py
@@ -134,8 +134,8 @@ def generate_reference_trees(stands: StandList, **operation_params) -> StandList
 
     stratum_association_diameter_threshold = operation_params.get('stratum_association_diameter_threshold', 3)
 
-    for j, stand in enumerate(stands):
-        print(f"\rGenerating trees for stand {stand.identifier}    {j}/{len(stands)}", end="")
+    for j, stand in enumerate(stands, 1):
+        print(f"Generating trees for stand {stand.identifier}    {j}/{len(stands)}")
 
         tree_ordering = np.argsort(stand.reference_trees.identifier)
 

--- a/lukefi/metsi/sim/simulator.py
+++ b/lukefi/metsi/sim/simulator.py
@@ -16,7 +16,8 @@ def simulate_alternatives[T: ComputationalUnit](control: dict[str, Any],
     if db is not None:
         init_collected_data_tables(db, simconfig.collected_data)
 
-    for unit in units:
+    for i, unit in enumerate(units, 1):
+        print(f"Simulating stand {unit.identifier} ({i} of {len(units)})...")
         payload = SimulationPayload(unit)
         payload.computational_unit.update_aggregates()
         simconfig.transition.initialize(payload.computational_unit)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "lukefi.mela2"
 description = "Mela2.0 forestry simulator."
-version = "0.6.12"
+version = "0.6.13"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [


### PR DESCRIPTION
Stand identifier is printed to console in `simulate_alternatives` and the print statement in `generate_reference_trees` is fixed so that the numbering starts from one and sequential calls are printed on new lines.