### PR TITLE
ref: move `motti_state` copy logic to `finalize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.7.8] - 2026-04-24
+
+### Changed
+
+- Motti state copy logic relocated to `finalize`
+
 ## [0.7.7] - 2026-04-22
 
 ### Fixed

--- a/lukefi/metsi/data/model.py
+++ b/lukefi/metsi/data/model.py
@@ -410,6 +410,39 @@ class ForestStand(Finalizable, ComputationalUnit):
         retval = copy(self)
         retval.reference_trees = self.reference_trees.finalize()
         retval.tree_strata = self.tree_strata.finalize()
+
+        if self.motti_state is not None:
+            dll = self.motti_state.dll
+            yy = self.motti_state.yy
+            yp = self.motti_state.yp
+            buffers = self.motti_state.buffers
+            ntrees = self.motti_state.ntrees
+            signature = self.motti_state.signature
+
+            if dll is None or yy is None or yp is None or buffers is None or ntrees is None:
+                retval.motti_state = None
+                return retval
+            if signature is None:
+                retval.motti_state = None
+                return retval
+            try:
+                yy2 = dll.clone_site(yy)
+                yp2 = dll.clone_trees(yp)
+                buffers2 = dll.clone_state_buffers(buffers)
+            except (AttributeError, TypeError, ValueError, RuntimeError):
+                # cloning failed -> drop state rather than share pointers
+                retval.motti_state = None
+                return retval
+
+            retval.motti_state = MottiState(
+                dll=dll,
+                yy=yy2,
+                yp=yp2,
+                ntrees=int(ntrees),
+                buffers=buffers2,
+                signature=cast(tuple[int, ...], signature),
+            )
+
         return retval
 
     @override
@@ -499,50 +532,6 @@ class ForestStand(Finalizable, ComputationalUnit):
         denominator = min(100, sorted_cum_stems[i_100_largest])
 
         return (numerator_1 + numerator_2) / denominator
-
-    def __copy__(self):
-        """Make branch-safe copies: clone Motti CFFI buffers so branches don't share state."""
-        new_obj = self.__class__(**{k: copy(v) for k, v in self.__dict__.items() if k != "motti_state"})
-
-        ms = self.motti_state
-        if ms is None:
-            new_obj.motti_state = None
-            return new_obj
-
-        dll = getattr(ms, "dll", None)
-        yy = getattr(ms, "yy", None)
-        yp = getattr(ms, "yp", None)
-        buffers = getattr(ms, "buffers", None)
-        ntrees = getattr(ms, "ntrees", None)
-        signature = getattr(ms, "signature", None)
-
-        if dll is None or yy is None or yp is None or buffers is None or ntrees is None:
-            new_obj.motti_state = None
-            return new_obj
-        if signature is None:
-            new_obj.motti_state = None
-            return new_obj
-        try:
-            yy2 = dll.clone_site(yy)
-            yp2 = dll.clone_trees(yp)
-            buffers2 = dll.clone_state_buffers(buffers)
-        except (AttributeError, TypeError, ValueError, RuntimeError):
-            # cloning failed -> drop state rather than share pointers
-            new_obj.motti_state = None
-            return new_obj
-
-        new_obj.motti_state = MottiState(
-            dll=dll,
-            yy=yy2,
-            yp=yp2,
-            ntrees=int(ntrees),
-            buffers=buffers2,
-            signature=cast(tuple[int, ...], signature),
-        )
-        return new_obj
-
-    def __deepcopy__(self, memo):
-        return self.__copy__()
 
 
 def stand_as_internal_csv_row(stand: ForestStand, decl_keys: Optional[list[str]] = None) -> list[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "lukefi.mela2"
 description = "Mela2.0 forestry simulator."
-version = "0.7.7"
+version = "0.7.8"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [


### PR DESCRIPTION
Relocated custom copy logic for Motti state to `finalize` to avoid potential side effects (in declarative conversions, for example).