### PR TITLE
fix: strip whitespace in `convert_peatland_forest_type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.7.6] - 2026-04-22
+
+### Fixed
+
+- Added removal of extra whitespace in peatland forest type conversion
+
 ## [0.7.5] - 2026-04-22
 
 ### Added

--- a/lukefi/metsi/data/conversion/vmi2internal.py
+++ b/lukefi/metsi/data/conversion/vmi2internal.py
@@ -378,6 +378,7 @@ def check_empty_vmi[T](func: Callable[[str], T]) -> Callable[[str], Optional[T]]
 
 @check_empty_vmi
 def convert_peatland_forest_type(code: str) -> Optional[PeatlandForestType]:
+    code = code.strip()
     if code == '0':
         return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "lukefi.mela2"
 description = "Mela2.0 forestry simulator."
-version = "0.7.5"
+version = "0.7.6"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [


### PR DESCRIPTION
Whitespace is now stripped from the source string in `convert_peatland_forest_type` before conversion to NFI enumerated type.