### PR TITLE
chore: add authors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ authors = [
     { name = "Juho-Petteri Yliuntinen" },
     { name = "Laura Jaakkola" },
     { name = "Urho Niemelä" },
+    { name = "Ari-Antti Tervonen" },
+    { name = "Tapani Stylman" }
 ]
 dependencies = [
     "jsonpickle==4.1.1",


### PR DESCRIPTION
Added Ari-Antti Tervonen and Tapani Stylman as authors in pyproject.toml.