### PR TITLE
fix: unique node identifiers for repeated transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.7.9] - 2026-05-08
+
+### Fixed
+
+- Repeated transitions now properly get unique node identifiers with multiple `-T`
+
 ## [0.7.8] - 2026-04-24
 
 ### Changed

--- a/lukefi/metsi/domain/utils/file_io.py
+++ b/lukefi/metsi/domain/utils/file_io.py
@@ -194,7 +194,7 @@ def output_node_to_db[T: ComputationalUnit](db: sqlite3.Connection,
 
 def update_leaf_node[T: ComputationalUnit](
         db: sqlite3.Connection,
-        leaf_node: SimulationPayload[T], 
+        leaf_node: SimulationPayload[T],
         transition_count: int):
     cur = db.cursor()
     node_id = "-".join(map(str, leaf_node.node_id))

--- a/lukefi/metsi/domain/utils/file_io.py
+++ b/lukefi/metsi/domain/utils/file_io.py
@@ -160,7 +160,7 @@ def output_node_to_db[T: ComputationalUnit](db: sqlite3.Connection,
                                             tags: Optional[set[str]] = None,
                                             output_state: bool = True,
                                             output_collected_data: bool = True,
-                                            is_transition: bool = False):
+                                            transition_count: int = 0):
     """
     Writes current simulation state and collected data to database.
 
@@ -171,8 +171,8 @@ def output_node_to_db[T: ComputationalUnit](db: sqlite3.Connection,
     if tags is None:
         tags = set()
     node_str = "-".join(map(str, current.node_id))
-    if is_transition:
-        node_str += "-T"
+    if transition_count:
+        node_str += "-T" * transition_count
     cur = db.cursor()
     cur.execute(
         """--sql
@@ -192,7 +192,10 @@ def output_node_to_db[T: ComputationalUnit](db: sqlite3.Connection,
             datum.output_to_db(db, node_str, current.computational_unit.identifier)
 
 
-def update_leaf_node[T: ComputationalUnit](db: sqlite3.Connection, leaf_node: SimulationPayload[T]):
+def update_leaf_node[T: ComputationalUnit](
+        db: sqlite3.Connection,
+        leaf_node: SimulationPayload[T], 
+        transition_count: int):
     cur = db.cursor()
     node_id = "-".join(map(str, leaf_node.node_id))
     cur.execute(
@@ -217,7 +220,7 @@ def update_leaf_node[T: ComputationalUnit](db: sqlite3.Connection, leaf_node: Si
             AND stand = ?;
         """,
         (
-            node_id + "-T",
+            node_id + ("-T" * transition_count),
             leaf_node.computational_unit.identifier
         )
     )

--- a/lukefi/metsi/sim/sim_configuration.py
+++ b/lukefi/metsi/sim/sim_configuration.py
@@ -58,7 +58,11 @@ class Transition[T: ComputationalUnit]:
         if self.init_fn is not None:
             self.init_fn(unit, self.parameters)
 
-    def __call__(self, payload: SimulationPayload[T], db: Optional[sqlite3.Connection], time_step: int) -> OpTuple[T]:
+    def __call__(self,
+                 payload: SimulationPayload[T],
+                 db: Optional[sqlite3.Connection],
+                 time_step: int,
+                 transition_count: int = 1) -> OpTuple[T]:
         if self.max_step is not None:
             time_step = min(time_step, self.max_step)
         new_state, collected_data = self.transition_fn(payload.computational_unit, time_step, **self.parameters)
@@ -69,7 +73,7 @@ class Transition[T: ComputationalUnit]:
             ]
             transition_payload = SimulationPayload(new_state, temp_history, payload.node_id)
             output_node_to_db(db, transition_payload, collected_data, output_state=self.db_output_state,
-                              output_collected_data=self.db_output_cd, is_transition=True)
+                              output_collected_data=self.db_output_cd, transition_count=transition_count)
 
         return new_state, collected_data
 

--- a/lukefi/metsi/sim/simulator.py
+++ b/lukefi/metsi/sim/simulator.py
@@ -31,7 +31,8 @@ def simulate_alternatives[T: ComputationalUnit](control: dict[str, Any],
 
 def _simulate_unit[T: ComputationalUnit](payload: SimulationPayload[T],
                                          config: SimConfiguration[T],
-                                         db: Optional[sqlite3.Connection] = None) -> list[SimulationPayload[T]]:
+                                         db: Optional[sqlite3.Connection] = None,
+                                         transition_count: int = 0) -> list[SimulationPayload[T]]:
     retval = []
     if not config.end_condition(payload):
         offset = 0
@@ -47,7 +48,7 @@ def _simulate_unit[T: ComputationalUnit](payload: SimulationPayload[T],
                             config.transition.max_step)
                         new_branch.computational_unit, _ = config.transition(new_branch, db, time_step)
                         new_branch.computational_unit.update_aggregates()
-                        retval.extend(_simulate_unit(new_branch, config, db))
+                        retval.extend(_simulate_unit(new_branch, config, db, 1))
                 offset += 1
         if all_instructions_failed:
             # All instructions had failed conditions. Create one branch to carry on with transition.
@@ -55,13 +56,14 @@ def _simulate_unit[T: ComputationalUnit](payload: SimulationPayload[T],
                 payload,
                 config.instructions,
                 config.transition.max_step)
-            payload.computational_unit, _ = config.transition(payload, db, time_step)
+            transition_count += 1
+            payload.computational_unit, _ = config.transition(payload, db, time_step, transition_count)
             payload.computational_unit.update_aggregates()
-            retval.extend(_simulate_unit(payload, config, db))
+            retval.extend(_simulate_unit(payload, config, db, transition_count))
     else:
         # End condition met, update `leaf` column
         if db is not None:
-            update_leaf_node(db, payload)
+            update_leaf_node(db, payload, transition_count)
         retval = [payload]
 
     return retval

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "lukefi.mela2"
 description = "Mela2.0 forestry simulator."
-version = "0.7.8"
+version = "0.7.9"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [


### PR DESCRIPTION
`-T` is now appended to the node identifier repeatedly when transitions are performed back-to-back (when no conditions are true after a single transition).