### PR TITLE
chore: add examples to setuptools package-dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.7.10] - 2026-05-08
+
+### Fixed
+
+- Added examples directory to setuptools `package-dir` list for proper package discovery
+
 ## [0.7.9] - 2026-05-08
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "lukefi.mela2"
 description = "Mela2.0 forestry simulator."
-version = "0.7.9"
+version = "0.7.10"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ mela2 = "lukefi.metsi.app.metsi:main"
 
 [tool.setuptools.package-dir]
 lukefi = "lukefi"
+examples = "examples"
 
 [tool.setuptools.package-data]
 "lukefi.metsi.forestry.lua" = ["*"]


### PR DESCRIPTION
Added examples directory to setuptools `package-dir` list for package discovery.