### PR TITLE
fix: read `koealan_kasittelyluokka` for VMI10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.8.3] - 2026-05-15
+
+### Fixed
+
+- `koealan_kasittelyluokka` is now properly read from VMI10 source data
+
 ## [0.8.2] - 2026-05-12
 
 ### Fixed

--- a/lukefi/metsi/data/formats/nfi/vmi10_builder.py
+++ b/lukefi/metsi/data/formats/nfi/vmi10_builder.py
@@ -167,7 +167,7 @@ class VMI10Builder(VMIBuilder):
                 row["muut_arvot"],
                 row["suojametsakoodi"],
                 row["ahvenanmaan_markkinahakkuualue"],
-                ""
+                row["koealan_kasittelyluokka"]
             )
         else:
             result.forest_management_category = 1

--- a/lukefi/metsi/data/formats/nfi/vmi_const.py
+++ b/lukefi/metsi/data/formats/nfi/vmi_const.py
@@ -168,6 +168,21 @@ VMI10_STAND_INDICES: dict[str, slice] = {
     "jakso1_keskipituus_dm": slice(233, 236),        # keskipit (col 234-236)
     "jakso1_d13ika": slice(237, 240),                # d13ika (col 238-240)
     "jakso1_ikalisays": slice(241, 243),             # ikalis (col 242-243)
+    "metsikon_ika": slice(255, 258),  # metika (cols 256-258)
+    "hakkuu_tapa": slice(262, 263),
+    "hakkuu_aika": slice(263, 264),
+    "maanmuokkaus_aika": slice(269, 270),
+    "viljely": slice(270, 271),
+    "viljely_aika": slice(271, 272),
+    "muu_toimenpide": slice(274, 275),
+    "muu_toimenpide_aika": slice(275, 276),
+    "hakkuuehdotus": slice(276, 277),  # hakehd1
+    "ppa1": slice(284, 287),
+    "ppa2": slice(288, 291),
+    "ppa3": slice(292, 295),
+    "ppa4": slice(296, 299),
+    "ppa5": slice(300, 303),
+    "basal_area": slice(305, 307),                  # kuvppa, kuvion ppa
     "jakso2_ppa": slice(307, 309),                   # j2ppa (cols 308-309)
     "jakso2_asema": slice(310, 311),                 # j2asema (col 311)
     "jakso2_syntytapa": slice(312, 313),             # j2syntapa (col 313)
@@ -184,21 +199,7 @@ VMI10_STAND_INDICES: dict[str, slice] = {
     "jakso2_keskipituus_dm": slice(343, 346),        # j2keskipit (col 344-346)
     "jakso2_d13ika": slice(347, 350),                # j2d13ika (col 348-350)
     "jakso2_ikalisays": slice(351, 353),             # j2ikalis (col 352-353)
-    "metsikon_ika": slice(255, 258),  # metika (cols 256-258)
-    "hakkuu_tapa": slice(262, 263),
-    "hakkuu_aika": slice(263, 264),
-    "maanmuokkaus_aika": slice(269, 270),
-    "viljely": slice(270, 271),
-    "viljely_aika": slice(271, 272),
-    "muu_toimenpide": slice(274, 275),
-    "muu_toimenpide_aika": slice(275, 276),
-    "hakkuuehdotus": slice(276, 277),  # hakehd1
-    "ppa1": slice(284, 287),
-    "ppa2": slice(288, 291),
-    "ppa3": slice(292, 295),
-    "ppa4": slice(296, 299),
-    "ppa5": slice(300, 303),
-    "basal_area": slice(305, 307),                  # kuvppa, kuvion ppa
+    "koealan_kasittelyluokka": slice(413, 416)
 }
 
 VMI10_TREE_INDICES: dict[str, slice] = {

--- a/lukefi/metsi/data/formats/nfi/vmi_const.py
+++ b/lukefi/metsi/data/formats/nfi/vmi_const.py
@@ -199,7 +199,7 @@ VMI10_STAND_INDICES: dict[str, slice] = {
     "jakso2_keskipituus_dm": slice(343, 346),        # j2keskipit (col 344-346)
     "jakso2_d13ika": slice(347, 350),                # j2d13ika (col 348-350)
     "jakso2_ikalisays": slice(351, 353),             # j2ikalis (col 352-353)
-    "koealan_kasittelyluokka": slice(413, 416)
+    "koealan_kasittelyluokka": slice(412, 415)
 }
 
 VMI10_TREE_INDICES: dict[str, slice] = {

--- a/lukefi/metsi/data/formats/nfi/vmi_util.py
+++ b/lukefi/metsi/data/formats/nfi/vmi_util.py
@@ -11,6 +11,11 @@ from lukefi.metsi.app.utils import MetsiException
 
 
 def generate_source_data(indices: dict[str, slice], row: str) -> dict[str, str]:
+    """
+        Create a dictionary of source data values from raw data row and index description.
+        If the data row does not contain an index (i.e. the row is cut short)
+        an empty string is returned natively when indexing by the slice.
+    """
     return {key: row[index] for key, index in indices.items()}
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "lukefi.mela2"
 description = "Mela2.0 forestry simulator."
-version = "0.8.2"
+version = "0.8.3"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [


### PR DESCRIPTION
Added index for `koealan_kasittelyluokka` in VMI10_STAND_INDICES and subsequent use in determining forest management category.