### PR TITLE
fix: remove simulate unit retval

### DIFF
--- a/lukefi/metsi/sim/simulator.py
+++ b/lukefi/metsi/sim/simulator.py
@@ -32,22 +32,21 @@ def simulate_alternatives[T: ComputationalUnit](control: dict[str, Any],
 def _simulate_unit[T: ComputationalUnit](payload: SimulationPayload[T],
                                          config: SimConfiguration[T],
                                          db: Optional[sqlite3.Connection] = None,
-                                         transition_count: int = 0) -> list[SimulationPayload[T]]:
-    retval = []
+                                         transition_count: int = 0):
     if not config.end_condition(payload):
         offset = 0
         all_instructions_failed = True
         for instruction in config.instructions:
             if all(condition(payload) for condition in instruction.conditions):
                 all_instructions_failed = False
-                for new_branch in instruction.evaluate(copy(payload), db, node = offset):
+                for new_branch in instruction.evaluate(copy(payload), db, node=offset):
                     time_step = _find_next_time_step(
                         new_branch,
                         config.instructions,
                         config.transition.max_step)
                     new_branch.computational_unit, _ = config.transition(new_branch, db, time_step)
                     new_branch.computational_unit.update_aggregates()
-                    retval.extend(_simulate_unit(new_branch, config, db, 1))
+                    _simulate_unit(new_branch, config, db, 1)
                 offset += instruction.event_generator.width()
         if all_instructions_failed:
             # All instructions had failed conditions. Create one branch to carry on with transition.
@@ -58,14 +57,11 @@ def _simulate_unit[T: ComputationalUnit](payload: SimulationPayload[T],
             transition_count += 1
             payload.computational_unit, _ = config.transition(payload, db, time_step, transition_count)
             payload.computational_unit.update_aggregates()
-            retval.extend(_simulate_unit(payload, config, db, transition_count))
+            _simulate_unit(payload, config, db, transition_count)
     else:
         # End condition met, update `leaf` column
         if db is not None:
             update_leaf_node(db, payload, transition_count)
-        retval = [payload]
-
-    return retval
 
 
 def _find_next_time_step[T: ComputationalUnit](payload: SimulationPayload[T],

--- a/tests/sim/simulation_instructions_test.py
+++ b/tests/sim/simulation_instructions_test.py
@@ -1,5 +1,7 @@
+import sqlite3
 import unittest
 
+from lukefi.metsi.domain.utils.file_io import create_database_tables
 from lukefi.metsi.sim.condition import Condition
 from lukefi.metsi.sim.generators import Alternatives, Event
 from lukefi.metsi.sim.sim_configuration import SimConfiguration
@@ -40,19 +42,37 @@ class SimulationInstructionsTest(unittest.TestCase):
 
         config = SimConfiguration[ToyModel](**declaration)
         payload = SimulationPayload[ToyModel](computational_unit=ToyModel("test", 0))
+        db = sqlite3.connect(":memory:")
+        ToyModel.init_db_tables(db)
+        _simulate_unit(payload, config, db)
 
-        results = _simulate_unit(payload, config)
+        cur = db.cursor()
+        cur.execute(
+            """--sql
+                SELECT COUNT(*) FROM nodes WHERE leaf == 1;
+            """)
+        leaf_count = cur.fetchone()[0]
 
-        self.assertEqual(27, len(results))
-        self.assertListEqual(
-            [[0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 0, 2], [0, 0, 1, 0], [0, 0, 1, 1], [0, 0, 1, 2],
-             [0, 0, 2, 0], [0, 0, 2, 1], [0, 0, 2, 2], [0, 1, 0, 0], [0, 1, 0, 1], [0, 1, 0, 2],
-             [0, 1, 1, 0], [0, 1, 1, 1], [0, 1, 1, 2], [0, 1, 2, 0], [0, 1, 2, 1], [0, 1, 2, 2],
-             [0, 2, 0, 0], [0, 2, 0, 1], [0, 2, 0, 2], [0, 2, 1, 0], [0, 2, 1, 1], [0, 2, 1, 2],
-             [0, 2, 2, 0], [0, 2, 2, 1], [0, 2, 2, 2],],
-            [result.node_id for result in results]
+        self.assertEqual(27, leaf_count)
+        cur.execute(
+            """--sql
+                SELECT identifier FROM nodes WHERE leaf == 1;
+            """
+        )
+        leaf_node_ids_expected = ["0-0-0-0", "0-0-0-1", "0-0-0-2", "0-0-1-0", "0-0-1-1", "0-0-1-2",
+             "0-0-2-0", "0-0-2-1", "0-0-2-2", "0-1-0-0", "0-1-0-1", "0-1-0-2",
+             "0-1-1-0", "0-1-1-1", "0-1-1-2", "0-1-2-0", "0-1-2-1", "0-1-2-2",
+             "0-2-0-0", "0-2-0-1", "0-2-0-2", "0-2-1-0", "0-2-1-1", "0-2-1-2",
+             "0-2-2-0", "0-2-2-1", "0-2-2-2",]
+
+        self.assertListEqual(leaf_node_ids_expected, [res[0] for res in cur])
+
+        cur.execute(
+            """--sql
+                SELECT value FROM toys, nodes WHERE nodes.stand = toys.identifier AND nodes.identifier = toys.node AND nodes.leaf = 1
+            """
         )
         self.assertListEqual(
             [3, 4, 5, 4, 5, 6, 5, 6, 7, 4, 5, 6, 5, 6, 7, 6, 7, 8, 5, 6, 7, 6, 7, 8, 7, 8, 9],
-            [result.computational_unit.value for result in results]
+            [res[0] for res in cur]
         )

--- a/tests/sim/simulator_test.py
+++ b/tests/sim/simulator_test.py
@@ -40,8 +40,6 @@ class SimulatorTest(unittest.TestCase):
         db = sqlite3.connect(":memory:")
         ToyModel.init_db_tables(db)
         _simulate_unit(payload, config, db)
-        # self.assertEqual(1, len(result))
-        # self.assertEqual(4, result[0].computational_unit.value)
         cur = db.cursor()
         cur.execute(
             """--sql
@@ -78,7 +76,6 @@ class SimulatorTest(unittest.TestCase):
         db = sqlite3.connect(":memory:")
         ToyModel.init_db_tables(db)
         _simulate_unit(payload, config, db)
-        # self.assertEqual(2, computation_result[0].computational_unit.value)
         cur = db.cursor()
         cur.execute(
             """--sql
@@ -128,7 +125,6 @@ class SimulatorTest(unittest.TestCase):
                 SELECT COUNT(*) FROM nodes WHERE leaf=1;
             """
         )
-        # self.assertEqual(0, len(computation_result))
         self.assertEqual(0, cur.fetchone()[0])
 
     def test_relative_time_points(self):
@@ -169,7 +165,6 @@ class SimulatorTest(unittest.TestCase):
                     nodes.leaf = 1;
             """
         )
-        # self.assertEqual(2, computation_result[0].computational_unit.value)
         self.assertEqual(2, cur.fetchone()[0])
 
     def test_nested_tree_generators(self):
@@ -234,7 +229,6 @@ class SimulatorTest(unittest.TestCase):
             """
         )
 
-        # self.assertListEqual([5, 6, 7, 8], list(map(lambda result: result.computational_unit.value, results)))
         self.assertListEqual([5, 6, 7, 8], [row[0] for row in cur])
 
     def test_nested_tree_generators_multiparameter_alternative(self):
@@ -301,7 +295,6 @@ class SimulatorTest(unittest.TestCase):
                     nodes.leaf = 1;
             """
         )
-        # self.assertListEqual([3, 4, 5], list(map(lambda result: result.computational_unit.value, results)))
         self.assertListEqual([3, 4, 5], [row[0] for row in cur])
 
     def test_alternatives_embedding_equivalence(self):
@@ -390,29 +383,28 @@ class SimulatorTest(unittest.TestCase):
             db2
         )
 
-        # results = (
-        #     list(
-        #         map(
-        #             lambda x: x.computational_unit.value,
-        #             _simulate_unit(
-        #                 SimulationPayload(
-        #                     computational_unit=ToyModel(
-        #                         "",
-        #                         0),
-        #                     operation_history=[]),
-        #                 configs[0]))),
-        #     list(
-        #         map(
-        #             lambda x: x.computational_unit.value,
-        #             _simulate_unit(
-        #                 SimulationPayload(
-        #                     computational_unit=ToyModel(
-        #                         "",
-        #                         0),
-        #                     operation_history=[]),
-        #                 configs[1]))))
+        value_query = """--sql
+            SELECT node, value FROM toys, nodes
+            WHERE
+                toys.node = nodes.identifier AND
+                toys.identifier = nodes.stand AND
+                nodes.leaf = 1;
+        """
 
-        # self.assertListEqual(results[0], results[1])
+        cur1 = db1.cursor()
+        cur2 = db2.cursor()
+        cur1.execute(value_query)
+        cur2.execute(value_query)
+
+        results1 = cur1.fetchall()
+        results2 = cur2.fetchall()
+        nodes1 = [row[0] for row in results1]
+        nodes2 = [row[0] for row in results2]
+        values1 = [row[1] for row in results1]
+        values2 = [row[1] for row in results2]
+
+        self.assertListEqual(values1, values2)
+        self.assertListEqual(nodes1, nodes2)
 
     def test_full_formation_evaluation_strategies_by_comparison(self):
         control_path = str(Path("tests",
@@ -425,9 +417,19 @@ class SimulatorTest(unittest.TestCase):
             computational_unit=ToyModel("", 1),
             operation_history=[]
         )
-        # results_depth = collect_results(
-        _simulate_unit(depth_payload, config)
-        # self.assertEqual(8, len(results_depth))
+
+        db = sqlite3.connect(":memory:")
+        ToyModel.init_db_tables(db)
+
+        _simulate_unit(depth_payload, config, db)
+        cur = db.cursor()
+        cur.execute(
+            """--sql
+                SELECT COUNT(*) FROM nodes WHERE leaf = 1;
+            """
+        )
+
+        self.assertEqual(8, cur.fetchone()[0])
 
     def test_no_parameters_propagation(self):
         control_path = str(Path("tests",
@@ -440,9 +442,20 @@ class SimulatorTest(unittest.TestCase):
             computational_unit=ToyModel("", 1),
             operation_history=[]
         )
-        # results = collect_results(
-        _simulate_unit(initial, config)
-        # self.assertEqual(5, results[0].value)
+        db = sqlite3.connect(":memory:")
+        ToyModel.init_db_tables(db)
+        _simulate_unit(initial, config, db)
+        cur = db.cursor()
+        cur.execute(
+            """--sql
+                SELECT value FROM toys, nodes
+                WHERE
+                    toys.identifier = nodes.stand AND
+                    toys.node = nodes.identifier AND
+                    leaf = 1;
+            """
+        )
+        self.assertEqual(5, cur.fetchone()[0])
 
     def test_parameters_propagation(self):
         control_path = str(Path("tests",
@@ -455,9 +468,20 @@ class SimulatorTest(unittest.TestCase):
             computational_unit=ToyModel("", 1),
             operation_history=[]
         )
-        # results = collect_results(
-        _simulate_unit(initial, config)
-        # self.assertEqual(9, results[0].value)
+        db = sqlite3.connect(":memory:")
+        ToyModel.init_db_tables(db)
+        _simulate_unit(initial, config, db)
+        cur = db.cursor()
+        cur.execute(
+            """--sql
+                SELECT value FROM toys, nodes
+                WHERE
+                    toys.identifier = nodes.stand AND
+                    toys.node = nodes.identifier AND
+                    leaf = 1;
+            """
+        )
+        self.assertEqual(9, cur.fetchone()[0])
 
     def test_parameters_branching(self):
         control_path = str(Path("tests",
@@ -470,7 +494,20 @@ class SimulatorTest(unittest.TestCase):
             computational_unit=ToyModel("", 1),
             operation_history=[]
         )
-        # results = list(map(lambda x: x.value, collect_results(_simulate_unit(initial, config))))
+        db = sqlite3.connect(":memory:")
+        ToyModel.init_db_tables(db)
+        _simulate_unit(initial, config, db)
+        cur = db.cursor()
+        cur.execute(
+            """--sql
+                SELECT value FROM toys, nodes
+                WHERE
+                    toys.identifier = nodes.stand AND
+                    toys.node = nodes.identifier AND
+                    nodes.leaf = 1;
+            """
+        )
+        results = [row[0] for row in cur]
         # do_nothing, do_nothing = 1
         # do_nothing, inc#1      = 2
         # do_nothing, inc#2      = 3
@@ -481,7 +518,7 @@ class SimulatorTest(unittest.TestCase):
         # inc#2, inc#1           = 4
         # inc#2, inc#2           = 5
         expected = [1, 2, 3, 2, 3, 4, 3, 4, 5]
-        # self.assertEqual(expected, results)
+        self.assertEqual(expected, results)
 
     def test_multiple_instructions(self):
         declaration = {
@@ -512,19 +549,34 @@ class SimulatorTest(unittest.TestCase):
 
         config = SimConfiguration[ToyModel](**declaration)
         payload = SimulationPayload[ToyModel](computational_unit=ToyModel("test", 0))
+        db = sqlite3.connect(":memory:")
+        ToyModel.init_db_tables(db)
+        _simulate_unit(payload, config, db)
 
-        results = _simulate_unit(payload, config)
+        cur = db.cursor()
+        cur.execute(
+            """--sql
+                SELECT node, value FROM toys, nodes
+                WHERE
+                    toys.identifier = nodes.stand AND
+                    toys.node = nodes.identifier AND
+                    nodes.leaf = 1;
+            """
+        )
+        results = cur.fetchall()
+        nodes = [result[0] for result in results]
+        values = [result[1] for result in results]
 
-        # self.assertEqual(27, len(results))
-        # self.assertListEqual(
-        #     [[0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 0, 2], [0, 0, 1, 0], [0, 0, 1, 1], [0, 0, 1, 2],
-        #      [0, 0, 2, 0], [0, 0, 2, 1], [0, 0, 2, 2], [0, 1, 0, 0], [0, 1, 0, 1], [0, 1, 0, 2],
-        #      [0, 1, 1, 0], [0, 1, 1, 1], [0, 1, 1, 2], [0, 1, 2, 0], [0, 1, 2, 1], [0, 1, 2, 2],
-        #      [0, 2, 0, 0], [0, 2, 0, 1], [0, 2, 0, 2], [0, 2, 1, 0], [0, 2, 1, 1], [0, 2, 1, 2],
-        #      [0, 2, 2, 0], [0, 2, 2, 1], [0, 2, 2, 2],],
-        #     [result.node_id for result in results]
-        # )
-        # self.assertListEqual(
-        #     [3, 4, 5, 4, 5, 6, 5, 6, 7, 4, 5, 6, 5, 6, 7, 6, 7, 8, 5, 6, 7, 6, 7, 8, 7, 8, 9],
-        #     [result.computational_unit.value for result in results]
-        # )
+        self.assertEqual(27, len(results))
+        self.assertListEqual(
+            ["0-0-0-0", "0-0-0-1", "0-0-0-2", "0-0-1-0", "0-0-1-1", "0-0-1-2",
+             "0-0-2-0", "0-0-2-1", "0-0-2-2", "0-1-0-0", "0-1-0-1", "0-1-0-2",
+             "0-1-1-0", "0-1-1-1", "0-1-1-2", "0-1-2-0", "0-1-2-1", "0-1-2-2",
+             "0-2-0-0", "0-2-0-1", "0-2-0-2", "0-2-1-0", "0-2-1-1", "0-2-1-2",
+             "0-2-2-0", "0-2-2-1", "0-2-2-2",],
+            nodes
+        )
+        self.assertListEqual(
+            [3, 4, 5, 4, 5, 6, 5, 6, 7, 4, 5, 6, 5, 6, 7, 6, 7, 8, 5, 6, 7, 6, 7, 8, 7, 8, 9],
+            values
+        )

--- a/tests/sim/simulator_test.py
+++ b/tests/sim/simulator_test.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import sqlite3
 import unittest
 
 from lukefi.metsi.app.file_io import read_control_module
@@ -10,7 +11,6 @@ from lukefi.metsi.sim.simulation_instruction import SimulationInstruction
 from lukefi.metsi.sim.simulation_payload import SimulationPayload
 from lukefi.metsi.sim.simulator import _simulate_unit
 from lukefi.metsi.sim.treatment import Treatment
-from tests.test_utils import collect_results
 from tests.toy_model import ToyModel, ToyTransition, toy_inc, toy_inc_fn
 
 
@@ -37,9 +37,18 @@ class SimulatorTest(unittest.TestCase):
             computational_unit=ToyModel("", 0),
             operation_history=[]
         )
-        result = _simulate_unit(payload, config)
-        self.assertEqual(1, len(result))
-        self.assertEqual(4, result[0].computational_unit.value)
+        db = sqlite3.connect(":memory:")
+        ToyModel.init_db_tables(db)
+        _simulate_unit(payload, config, db)
+        # self.assertEqual(1, len(result))
+        # self.assertEqual(4, result[0].computational_unit.value)
+        cur = db.cursor()
+        cur.execute(
+            """--sql
+                SELECT COUNT(*) FROM nodes WHERE leaf=1;
+            """
+        )
+        self.assertEqual(1, cur.fetchone()[0])
 
     def test_operation_run_constraints_success(self):
         declaration = {
@@ -66,8 +75,21 @@ class SimulatorTest(unittest.TestCase):
             computational_unit=ToyModel("", 0),
             operation_history=[]
         )
-        computation_result = _simulate_unit(payload, config)
-        self.assertEqual(2, computation_result[0].computational_unit.value)
+        db = sqlite3.connect(":memory:")
+        ToyModel.init_db_tables(db)
+        _simulate_unit(payload, config, db)
+        # self.assertEqual(2, computation_result[0].computational_unit.value)
+        cur = db.cursor()
+        cur.execute(
+            """--sql
+                SELECT value FROM toys, nodes
+                WHERE
+                    toys.identifier = nodes.stand AND
+                    toys.node = nodes.identifier AND
+                    nodes.leaf = 1;
+            """
+        )
+        self.assertEqual(2, cur.fetchone()[0])
 
     def test_operation_run_constraints_fail(self):
         declaration = {
@@ -96,9 +118,18 @@ class SimulatorTest(unittest.TestCase):
         config = SimConfiguration(**declaration)
         payload = SimulationPayload(computational_unit=ToyModel("", 0),
                                     operation_history=[])
-        computation_result = _simulate_unit(payload, config)
+        db = sqlite3.connect(":memory:")
+        ToyModel.init_db_tables(db)
+        _simulate_unit(payload, config, db)
 
-        self.assertEqual(0, len(computation_result))
+        cur = db.cursor()
+        cur.execute(
+            """--sql
+                SELECT COUNT(*) FROM nodes WHERE leaf=1;
+            """
+        )
+        # self.assertEqual(0, len(computation_result))
+        self.assertEqual(0, cur.fetchone()[0])
 
     def test_relative_time_points(self):
         declaration = {
@@ -125,8 +156,21 @@ class SimulatorTest(unittest.TestCase):
             computational_unit=ToyModel("", 0, time=200),
             operation_history=[]
         )
-        computation_result = _simulate_unit(payload, config)
-        self.assertEqual(2, computation_result[0].computational_unit.value)
+        db = sqlite3.connect(":memory:")
+        ToyModel.init_db_tables(db)
+        _simulate_unit(payload, config, db)
+        cur = db.cursor()
+        cur.execute(
+            """--sql
+                SELECT value FROM toys, nodes
+                WHERE
+                    toys.identifier = nodes.stand AND
+                    toys.node = nodes.identifier AND
+                    nodes.leaf = 1;
+            """
+        )
+        # self.assertEqual(2, computation_result[0].computational_unit.value)
+        self.assertEqual(2, cur.fetchone()[0])
 
     def test_nested_tree_generators(self):
         """Create a nested generators event tree. Use simple incrementation operation with starting value 0. Sequences
@@ -168,16 +212,30 @@ class SimulatorTest(unittest.TestCase):
             "end_condition": Condition[ToyModel](lambda x: x.computational_unit.time > 0)
         }
         config = SimConfiguration(**declaration)
+        db = sqlite3.connect(":memory:")
+        ToyModel.init_db_tables(db)
 
-        results = _simulate_unit(
+        _simulate_unit(
             SimulationPayload(
                 computational_unit=ToyModel(
                     "",
                     0),
                 operation_history=[]),
-            config)
+            config,
+            db)
+        cur = db.cursor()
+        cur.execute(
+            """--sql
+                SELECT value FROM toys, nodes
+                WHERE
+                    toys.identifier = nodes.stand AND
+                    toys.node = nodes.identifier AND
+                    nodes.leaf = 1;
+            """
+        )
 
-        self.assertListEqual([5, 6, 7, 8], list(map(lambda result: result.computational_unit.value, results)))
+        # self.assertListEqual([5, 6, 7, 8], list(map(lambda result: result.computational_unit.value, results)))
+        self.assertListEqual([5, 6, 7, 8], [row[0] for row in cur])
 
     def test_nested_tree_generators_multiparameter_alternative(self):
         def _increment(x, **y):
@@ -223,14 +281,28 @@ class SimulatorTest(unittest.TestCase):
             "transition": ToyTransition()
         }
         config = SimConfiguration(**declaration)
+        db = sqlite3.connect(":memory:")
+        ToyModel.init_db_tables(db)
 
-        results = _simulate_unit(
+        _simulate_unit(
             SimulationPayload(
                 computational_unit=ToyModel("", 0),
                 operation_history=[]),
-            config)
+            config,
+            db)
 
-        self.assertListEqual([3, 4, 5], list(map(lambda result: result.computational_unit.value, results)))
+        cur = db.cursor()
+        cur.execute(
+            """--sql
+                SELECT value FROM toys, nodes
+                WHERE
+                    toys.identifier = nodes.stand AND
+                    toys.node = nodes.identifier AND
+                    nodes.leaf = 1;
+            """
+        )
+        # self.assertListEqual([3, 4, 5], list(map(lambda result: result.computational_unit.value, results)))
+        self.assertListEqual([3, 4, 5], [row[0] for row in cur])
 
     def test_alternatives_embedding_equivalence(self):
         """
@@ -289,29 +361,58 @@ class SimulatorTest(unittest.TestCase):
             SimConfiguration(**declaration_two)
         ]
 
-        results = (
-            list(
-                map(
-                    lambda x: x.computational_unit.value,
-                    _simulate_unit(
-                        SimulationPayload(
-                            computational_unit=ToyModel(
-                                "",
-                                0),
-                            operation_history=[]),
-                        configs[0]))),
-            list(
-                map(
-                    lambda x: x.computational_unit.value,
-                    _simulate_unit(
-                        SimulationPayload(
-                            computational_unit=ToyModel(
-                                "",
-                                0),
-                            operation_history=[]),
-                        configs[1]))))
+        db1 = sqlite3.connect(":memory:")
+        db2 = sqlite3.connect(":memory:")
 
-        self.assertListEqual(results[0], results[1])
+        ToyModel.init_db_tables(db1)
+        ToyModel.init_db_tables(db2)
+
+        _simulate_unit(
+            SimulationPayload(
+                computational_unit=ToyModel(
+                    "one",
+                    0
+                ),
+                operation_history=[]
+            ),
+            configs[0],
+            db1
+        )
+        _simulate_unit(
+            SimulationPayload(
+                computational_unit=ToyModel(
+                    "two",
+                    0
+                ),
+                operation_history=[]
+            ),
+            configs[1],
+            db2
+        )
+
+        # results = (
+        #     list(
+        #         map(
+        #             lambda x: x.computational_unit.value,
+        #             _simulate_unit(
+        #                 SimulationPayload(
+        #                     computational_unit=ToyModel(
+        #                         "",
+        #                         0),
+        #                     operation_history=[]),
+        #                 configs[0]))),
+        #     list(
+        #         map(
+        #             lambda x: x.computational_unit.value,
+        #             _simulate_unit(
+        #                 SimulationPayload(
+        #                     computational_unit=ToyModel(
+        #                         "",
+        #                         0),
+        #                     operation_history=[]),
+        #                 configs[1]))))
+
+        # self.assertListEqual(results[0], results[1])
 
     def test_full_formation_evaluation_strategies_by_comparison(self):
         control_path = str(Path("tests",
@@ -324,9 +425,9 @@ class SimulatorTest(unittest.TestCase):
             computational_unit=ToyModel("", 1),
             operation_history=[]
         )
-        results_depth = collect_results(
-            _simulate_unit(depth_payload, config))
-        self.assertEqual(8, len(results_depth))
+        # results_depth = collect_results(
+        _simulate_unit(depth_payload, config)
+        # self.assertEqual(8, len(results_depth))
 
     def test_no_parameters_propagation(self):
         control_path = str(Path("tests",
@@ -339,9 +440,9 @@ class SimulatorTest(unittest.TestCase):
             computational_unit=ToyModel("", 1),
             operation_history=[]
         )
-        results = collect_results(
-            _simulate_unit(initial, config))
-        self.assertEqual(5, results[0].value)
+        # results = collect_results(
+        _simulate_unit(initial, config)
+        # self.assertEqual(5, results[0].value)
 
     def test_parameters_propagation(self):
         control_path = str(Path("tests",
@@ -354,9 +455,9 @@ class SimulatorTest(unittest.TestCase):
             computational_unit=ToyModel("", 1),
             operation_history=[]
         )
-        results = collect_results(
-            _simulate_unit(initial, config))
-        self.assertEqual(9, results[0].value)
+        # results = collect_results(
+        _simulate_unit(initial, config)
+        # self.assertEqual(9, results[0].value)
 
     def test_parameters_branching(self):
         control_path = str(Path("tests",
@@ -369,7 +470,7 @@ class SimulatorTest(unittest.TestCase):
             computational_unit=ToyModel("", 1),
             operation_history=[]
         )
-        results = list(map(lambda x: x.value, collect_results(_simulate_unit(initial, config))))
+        # results = list(map(lambda x: x.value, collect_results(_simulate_unit(initial, config))))
         # do_nothing, do_nothing = 1
         # do_nothing, inc#1      = 2
         # do_nothing, inc#2      = 3
@@ -380,7 +481,7 @@ class SimulatorTest(unittest.TestCase):
         # inc#2, inc#1           = 4
         # inc#2, inc#2           = 5
         expected = [1, 2, 3, 2, 3, 4, 3, 4, 5]
-        self.assertEqual(expected, results)
+        # self.assertEqual(expected, results)
 
     def test_multiple_instructions(self):
         declaration = {
@@ -414,16 +515,16 @@ class SimulatorTest(unittest.TestCase):
 
         results = _simulate_unit(payload, config)
 
-        self.assertEqual(27, len(results))
-        self.assertListEqual(
-            [[0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 0, 2], [0, 0, 1, 0], [0, 0, 1, 1], [0, 0, 1, 2],
-             [0, 0, 2, 0], [0, 0, 2, 1], [0, 0, 2, 2], [0, 1, 0, 0], [0, 1, 0, 1], [0, 1, 0, 2],
-             [0, 1, 1, 0], [0, 1, 1, 1], [0, 1, 1, 2], [0, 1, 2, 0], [0, 1, 2, 1], [0, 1, 2, 2],
-             [0, 2, 0, 0], [0, 2, 0, 1], [0, 2, 0, 2], [0, 2, 1, 0], [0, 2, 1, 1], [0, 2, 1, 2],
-             [0, 2, 2, 0], [0, 2, 2, 1], [0, 2, 2, 2],],
-            [result.node_id for result in results]
-        )
-        self.assertListEqual(
-            [3, 4, 5, 4, 5, 6, 5, 6, 7, 4, 5, 6, 5, 6, 7, 6, 7, 8, 5, 6, 7, 6, 7, 8, 7, 8, 9],
-            [result.computational_unit.value for result in results]
-        )
+        # self.assertEqual(27, len(results))
+        # self.assertListEqual(
+        #     [[0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 0, 2], [0, 0, 1, 0], [0, 0, 1, 1], [0, 0, 1, 2],
+        #      [0, 0, 2, 0], [0, 0, 2, 1], [0, 0, 2, 2], [0, 1, 0, 0], [0, 1, 0, 1], [0, 1, 0, 2],
+        #      [0, 1, 1, 0], [0, 1, 1, 1], [0, 1, 1, 2], [0, 1, 2, 0], [0, 1, 2, 1], [0, 1, 2, 2],
+        #      [0, 2, 0, 0], [0, 2, 0, 1], [0, 2, 0, 2], [0, 2, 1, 0], [0, 2, 1, 1], [0, 2, 1, 2],
+        #      [0, 2, 2, 0], [0, 2, 2, 1], [0, 2, 2, 2],],
+        #     [result.node_id for result in results]
+        # )
+        # self.assertListEqual(
+        #     [3, 4, 5, 4, 5, 6, 5, 6, 7, 4, 5, 6, 5, 6, 7, 6, 7, 8, 5, 6, 7, 6, 7, 8, 7, 8, 9],
+        #     [result.computational_unit.value for result in results]
+        # )

--- a/tests/toy_model.py
+++ b/tests/toy_model.py
@@ -17,11 +17,51 @@ class ToyModel(ComputationalUnit):
 
     @override
     def output_to_db(self, db: Connection, node: str):
-        pass
+        cur = db.cursor()
+        cur.execute(
+            """--sql
+                INSERT INTO toys
+                VALUES (?, ?, ?, ?)
+            """,
+            (
+                node,
+                self.identifier,
+                self.value,
+                self.time
+            )
+        )
 
     @override
     def update_aggregates(self):
         pass
+
+    @staticmethod
+    def init_db_tables(db: Connection):
+        cur = db.cursor()
+        cur.execute(
+        """--sql
+            CREATE TABLE nodes(
+                identifier TEXT,
+                stand TEXT,
+                done_treatment TEXT,
+                treatment_params TEXT,
+                tags TEXT,
+                leaf INTEGER(1) DEFAULT(0),
+                PRIMARY KEY(identifier, stand))
+        """
+        )
+        cur.execute(
+            """--sql
+                CREATE TABLE toys (
+                    node TEXT,
+                    identifier TEXT,
+                    value INTEGER,
+                    time INTEGER,
+                    PRIMARY KEY(node, identifier),
+                    FOREIGN KEY(node, identifier) REFERENCES nodes(identifier, stand)
+                )
+            """
+        )
 
 
 class ToyTransition(Transition[ToyModel]):


### PR DESCRIPTION
Removed collection of leaf node payloads in `_simulate_alternatives` and refactored unit tests to compare against in-memory database.