### PR TITLE
perf: db output optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.8.9] - 2026-06-17
+
+### Changed
+
+- Reduced database output performance overhead
+
 ## [0.8.8] - 2026-06-08
 
 ### Fixed

--- a/lukefi/metsi/app/file_io.py
+++ b/lukefi/metsi/app/file_io.py
@@ -240,7 +240,7 @@ def init_sqlite_database(file_path: str | Path) -> sqlite3.Connection:
             os.remove(file_path)
         except OSError as e:
             raise MetsiException(f"Unable to delete existing database file {file_path}") from e
-    db = sqlite3.connect(file_path)
+    db = sqlite3.connect(file_path, autocommit=False)
     return db
 
 

--- a/lukefi/metsi/data/model.py
+++ b/lukefi/metsi/data/model.py
@@ -349,20 +349,10 @@ class ForestStand(Finalizable, ComputationalUnit):
 
     @staticmethod
     def _sql_value(v):
-        # if v is None:
-            # return None
-        # if isinstance(v, Enum):
-            # return v.value
-        # numpy scalar -> python scalar
         if isinstance(v, (np.generic,)):
             return v.item()
-        # tuples / arrays that is store as TEXT
         if isinstance(v, (tuple, list, np.ndarray)):
             return str(v)
-        # numpy array row [x,y,z] -> (x, y, z)
-        # if isinstance(v, np.ndarray):
-            # return str(tuple(v.tolist()))
-        # for bool as bool
         return v
 
     @classmethod
@@ -481,30 +471,11 @@ class ForestStand(Finalizable, ComputationalUnit):
     def output_to_db(self, db: sqlite3.Connection, node: str):
         cur = db.cursor()
 
-        # def insert(table: str, cols: list[str], values: list):
-        # cur.execute(
-        # f"INSERT INTO {table} ({', '.join(cols)}) VALUES ({', '.join(['?'] * len(cols))})",
-        # tuple(values),
-        # )
-
         # ---- stands ----
-        # stand_cols = self._decl_cols("stands", list(STANDS_TYPES.keys()))
-        # insert(
-        # "stands",
-        # ["node", "identifier"] + stand_cols,
-        # [node, self.identifier] + [self._sql_value(getattr(self, c)) for c in stand_cols],
-        # )
-
         cur.execute(self.stands_insert_statement(), [node, self.identifier] +
                     [self._sql_value(getattr(self, c)) for c in self._stands_cols()])
 
         # ---- trees ----
-        # tree_cols = self._decl_cols("trees", list(TREES_TYPES.keys()))
-        # tree_insert_cols = ["node", "stand", "identifier"] + tree_cols
-        # trees = self.reference_trees
-        # for i in range(trees.size):
-        # row = [self._sql_value(getattr(trees, c)[i]) for c in tree_cols]
-        # insert("trees", tree_insert_cols, [node, self.identifier, trees.identifier[i]] + row)
         trees = self.reference_trees
         tree_attrs = [trees.identifier] + [getattr(trees, c) for c in self._trees_cols()]
         cur.executemany(
@@ -518,12 +489,6 @@ class ForestStand(Finalizable, ComputationalUnit):
         )
 
         # ---- strata ----
-        # strata_cols = self._decl_cols("strata", list(STRATA_TYPES.keys()))
-        # strata_insert_cols = ["node", "stand", "identifier"] + strata_cols
-        # strata = self.tree_strata
-        # for i in range(strata.size):
-        # row = [self._sql_value(getattr(strata, c)[i]) for c in strata_cols]
-        # insert("strata", strata_insert_cols, [node, self.identifier, strata.identifier[i]] + row)
         strata = self.tree_strata
         stratum_attrs = [strata.identifier] + [getattr(strata, c) for c in self._strata_cols()]
         cur.executemany(

--- a/lukefi/metsi/data/model.py
+++ b/lukefi/metsi/data/model.py
@@ -1,5 +1,4 @@
 from copy import copy
-from enum import Enum
 import dataclasses
 from functools import lru_cache
 import sqlite3

--- a/lukefi/metsi/data/model.py
+++ b/lukefi/metsi/data/model.py
@@ -1,6 +1,7 @@
 from copy import copy
 from enum import Enum
 import dataclasses
+from functools import lru_cache
 import sqlite3
 from typing import Optional, override, Any, cast
 from dataclasses import dataclass
@@ -57,7 +58,7 @@ class ForestStand(Finalizable, ComputationalUnit):
     """
     stand_id: Optional[int] = None
     """
-    Running unique identifier number for forest stands.    
+    Running unique identifier number for forest stands.
     """
     area: float = 0.0
     """
@@ -348,19 +349,19 @@ class ForestStand(Finalizable, ComputationalUnit):
 
     @staticmethod
     def _sql_value(v):
-        if v is None:
-            return None
-        if isinstance(v, Enum):
-            return v.value
+        # if v is None:
+            # return None
+        # if isinstance(v, Enum):
+            # return v.value
         # numpy scalar -> python scalar
         if isinstance(v, (np.generic,)):
             return v.item()
         # tuples / arrays that is store as TEXT
-        if isinstance(v, (tuple, list)):
-            return str(tuple(v))
+        if isinstance(v, (tuple, list, np.ndarray)):
+            return str(v)
         # numpy array row [x,y,z] -> (x, y, z)
-        if isinstance(v, np.ndarray):
-            return str(tuple(v.tolist()))
+        # if isinstance(v, np.ndarray):
+            # return str(tuple(v.tolist()))
         # for bool as bool
         return v
 
@@ -369,7 +370,31 @@ class ForestStand(Finalizable, ComputationalUnit):
         decl = cls.sqlite_decl
         if not decl:
             return default
-        return list(decl.get(table, default))
+        return decl.get(table, default)
+
+    @classmethod
+    @lru_cache
+    def _stands_cols(cls) -> list[str]:
+        decl = cls.sqlite_decl
+        if not decl:
+            return list(STANDS_TYPES.keys())
+        return decl.get("stands", list(STANDS_TYPES.keys()))
+
+    @classmethod
+    @lru_cache
+    def _trees_cols(cls) -> list[str]:
+        decl = cls.sqlite_decl
+        if not decl:
+            return list(TREES_TYPES.keys())
+        return decl.get("trees", list(TREES_TYPES.keys()))
+
+    @classmethod
+    @lru_cache
+    def _strata_cols(cls) -> list[str]:
+        decl = cls.sqlite_decl
+        if not decl:
+            return list(STRATA_TYPES.keys())
+        return decl.get("strata", list(STRATA_TYPES.keys()))
 
     @classmethod
     def set_sqlite_decl(cls, decl: Optional[dict]) -> None:
@@ -431,39 +456,85 @@ class ForestStand(Finalizable, ComputationalUnit):
 
         return retval
 
+    @classmethod
+    @lru_cache
+    def stands_insert_statement(cls):
+        cols = cls._stands_cols()
+        return f"INSERT INTO stands ({', '.join(["node", "identifier"] + cols)})"\
+            f"VALUES({', '.join(['?'] * (len(cols) + 2))})"
+
+    @classmethod
+    @lru_cache
+    def trees_insert_statement(cls):
+        cols = cls._trees_cols()
+        return f"INSERT INTO trees ({', '.join(["node", "stand", "identifier"] + cols)})"\
+            f"VALUES({', '.join(['?'] * (len(cols) + 3))})"
+
+    @classmethod
+    @lru_cache
+    def strata_insert_statement(cls):
+        cols = cls._strata_cols()
+        return f"INSERT INTO strata ({', '.join(["node", "stand", "identifier"] + cols)})"\
+            f"VALUES({', '.join(['?'] * (len(cols) + 3))})"
+
     @override
     def output_to_db(self, db: sqlite3.Connection, node: str):
         cur = db.cursor()
 
-        def insert(table: str, cols: list[str], values: list):
-            cur.execute(
-                f"INSERT INTO {table} ({', '.join(cols)}) VALUES ({', '.join(['?'] * len(cols))})",
-                tuple(values),
-            )
+        # def insert(table: str, cols: list[str], values: list):
+        # cur.execute(
+        # f"INSERT INTO {table} ({', '.join(cols)}) VALUES ({', '.join(['?'] * len(cols))})",
+        # tuple(values),
+        # )
 
         # ---- stands ----
-        stand_cols = self._decl_cols("stands", list(STANDS_TYPES.keys()))
-        insert(
-            "stands",
-            ["node", "identifier"] + stand_cols,
-            [node, self.identifier] + [self._sql_value(getattr(self, c)) for c in stand_cols],
-        )
+        # stand_cols = self._decl_cols("stands", list(STANDS_TYPES.keys()))
+        # insert(
+        # "stands",
+        # ["node", "identifier"] + stand_cols,
+        # [node, self.identifier] + [self._sql_value(getattr(self, c)) for c in stand_cols],
+        # )
+
+        cur.execute(self.stands_insert_statement(), [node, self.identifier] +
+                    [self._sql_value(getattr(self, c)) for c in self._stands_cols()])
 
         # ---- trees ----
-        tree_cols = self._decl_cols("trees", list(TREES_TYPES.keys()))
-        tree_insert_cols = ["node", "stand", "identifier"] + tree_cols
+        # tree_cols = self._decl_cols("trees", list(TREES_TYPES.keys()))
+        # tree_insert_cols = ["node", "stand", "identifier"] + tree_cols
+        # trees = self.reference_trees
+        # for i in range(trees.size):
+        # row = [self._sql_value(getattr(trees, c)[i]) for c in tree_cols]
+        # insert("trees", tree_insert_cols, [node, self.identifier, trees.identifier[i]] + row)
         trees = self.reference_trees
-        for i in range(trees.size):
-            row = [self._sql_value(getattr(trees, c)[i]) for c in tree_cols]
-            insert("trees", tree_insert_cols, [node, self.identifier, trees.identifier[i]] + row)
+        tree_attrs = [trees.identifier] + [getattr(trees, c) for c in self._trees_cols()]
+        cur.executemany(
+            self.trees_insert_statement(),
+            (
+                (
+                    [node, self.identifier] + [self._sql_value(tree_attr[i]) for tree_attr in tree_attrs]
+                )
+                for i in range(trees.size)
+            )
+        )
 
         # ---- strata ----
-        strata_cols = self._decl_cols("strata", list(STRATA_TYPES.keys()))
-        strata_insert_cols = ["node", "stand", "identifier"] + strata_cols
+        # strata_cols = self._decl_cols("strata", list(STRATA_TYPES.keys()))
+        # strata_insert_cols = ["node", "stand", "identifier"] + strata_cols
+        # strata = self.tree_strata
+        # for i in range(strata.size):
+        # row = [self._sql_value(getattr(strata, c)[i]) for c in strata_cols]
+        # insert("strata", strata_insert_cols, [node, self.identifier, strata.identifier[i]] + row)
         strata = self.tree_strata
-        for i in range(strata.size):
-            row = [self._sql_value(getattr(strata, c)[i]) for c in strata_cols]
-            insert("strata", strata_insert_cols, [node, self.identifier, strata.identifier[i]] + row)
+        stratum_attrs = [strata.identifier] + [getattr(strata, c) for c in self._strata_cols()]
+        cur.executemany(
+            self.strata_insert_statement(),
+            (
+                (
+                    [node, self.identifier] + [self._sql_value(stratum_attr[i]) for stratum_attr in stratum_attrs]
+                )
+                for i in range(strata.size)
+            )
+        )
 
     @override
     def update_aggregates(self):

--- a/lukefi/metsi/data/model.py
+++ b/lukefi/metsi/data/model.py
@@ -362,7 +362,7 @@ class ForestStand(Finalizable, ComputationalUnit):
         return decl.get(table, default)
 
     @classmethod
-    @lru_cache
+    @lru_cache(maxsize=1)
     def _stands_cols(cls) -> list[str]:
         decl = cls.sqlite_decl
         if not decl:
@@ -370,7 +370,7 @@ class ForestStand(Finalizable, ComputationalUnit):
         return decl.get("stands", list(STANDS_TYPES.keys()))
 
     @classmethod
-    @lru_cache
+    @lru_cache(maxsize=1)
     def _trees_cols(cls) -> list[str]:
         decl = cls.sqlite_decl
         if not decl:
@@ -378,7 +378,7 @@ class ForestStand(Finalizable, ComputationalUnit):
         return decl.get("trees", list(TREES_TYPES.keys()))
 
     @classmethod
-    @lru_cache
+    @lru_cache(maxsize=1)
     def _strata_cols(cls) -> list[str]:
         decl = cls.sqlite_decl
         if not decl:
@@ -446,21 +446,21 @@ class ForestStand(Finalizable, ComputationalUnit):
         return retval
 
     @classmethod
-    @lru_cache
+    @lru_cache(maxsize=1)
     def stands_insert_statement(cls):
         cols = cls._stands_cols()
         return f"INSERT INTO stands ({', '.join(["node", "identifier"] + cols)})"\
             f"VALUES({', '.join(['?'] * (len(cols) + 2))})"
 
     @classmethod
-    @lru_cache
+    @lru_cache(maxsize=1)
     def trees_insert_statement(cls):
         cols = cls._trees_cols()
         return f"INSERT INTO trees ({', '.join(["node", "stand", "identifier"] + cols)})"\
             f"VALUES({', '.join(['?'] * (len(cols) + 3))})"
 
     @classmethod
-    @lru_cache
+    @lru_cache(maxsize=1)
     def strata_insert_statement(cls):
         cols = cls._strata_cols()
         return f"INSERT INTO strata ({', '.join(["node", "stand", "identifier"] + cols)})"\
@@ -471,8 +471,10 @@ class ForestStand(Finalizable, ComputationalUnit):
         cur = db.cursor()
 
         # ---- stands ----
-        cur.execute(self.stands_insert_statement(), [node, self.identifier] +
-                    [self._sql_value(getattr(self, c)) for c in self._stands_cols()])
+        cur.execute(
+            self.stands_insert_statement(),
+            [node, self.identifier] + [self._sql_value(getattr(self, c)) for c in self._stands_cols()]
+        )
 
         # ---- trees ----
         trees = self.reference_trees

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "lukefi.mela2"
 description = "Mela2.0 forestry simulator."
-version = "0.8.8"
+version = "0.8.9"
 readme = "README.md"
 requires-python = "~=3.13"
 authors = [


### PR DESCRIPTION
Made database output faster by caching transaction strings and refactoring generator expressions so that `getattr` is not called for every `i`. Also added `autocommit=False` to the database `connect` call to enable [recommended transaction control](https://docs.python.org/3/library/sqlite3.html#sqlite3-transaction-control-autocommit).