### PR TITLE
chore: ignore pabot output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ tests/robot/**/output/test/
 output.xml
 log.html
 report.html
+# Parallel runner output
+.pabotsuitenames
+pabot_results/
 
 # Pytest coverage output
 .coverage


### PR DESCRIPTION
Added Pabot (Robot Framework parallel runner) output files to .gitignore.