### PR TITLE
chore: delete predetermined treatments after updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.11.2] - 2026-08-12
+
+### Added
+
+- Lists of predetermined treatments are now cleared once the treatments are performed by updating
+
 ## [0.11.1] - 2026-08-12
 
 ### Removed

--- a/lukefi/metsi/sim/updating.py
+++ b/lukefi/metsi/sim/updating.py
@@ -72,7 +72,8 @@ def update_units[T: ComputationalUnit](updating_instructions: UpdatingInstructio
             else:
                 keep_running = False
 
-        # TODO: delete current.comptutaional_unit.predetermined_treatments?
+        # Drop performed treatments
+        current.computational_unit.predetermined_treatments = None
 
         # Update starting time for relative timepoints
         current.computational_unit.start_time = current.computational_unit.time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "lukefi.mela2"
 description = "Mela2.0 forestry simulator."
-version = "0.11.1"
+version = "0.11.2"
 readme = "README.md"
 requires-python = "~=3.13"
 authors = [


### PR DESCRIPTION
The list of predetermined treatments is now dropped after updating is performed on a unit.